### PR TITLE
Jspf 102

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <version>1.8.3-SNAPSHOT</version>
     </parent>
 
+    <groupId>org.apache.james</groupId>
     <artifactId>apache-jspf-project</artifactId>
     <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,18 @@
     </dependencyManagement>
 
      <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <optimize>true</optimize>
+                    <source>${target.jdk}</source>
+                    <target>${target.jdk}</target>
+                </configuration>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <!-- See https://issues.apache.org/**jira/browse/FELIX-3037<https://issues.apache.org/jira/browse/FELIX-3037>-->


### PR DESCRIPTION
- Use java version 1.6 and not 1.4
- Group Id was removed, as no more inherited by parent, thus blocking release process
