### PR TITLE
Fix NPE while expanding %{p} (JSPF-99)

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/core/MacroExpand.java
+++ b/resolver/src/main/java/org/apache/james/jspf/core/MacroExpand.java
@@ -148,7 +148,6 @@ public class MacroExpand {
                 }
             } catch (TimeoutException e) {
                 // just return the default "unknown".
-                session.setClientDomain("unknown");
             }
                     
             session.setClientDomain("unknown");        

--- a/resolver/src/main/java/org/apache/james/jspf/core/MacroExpand.java
+++ b/resolver/src/main/java/org/apache/james/jspf/core/MacroExpand.java
@@ -150,6 +150,8 @@ public class MacroExpand {
                 // just return the default "unknown".
                 session.setClientDomain("unknown");
             }
+                    
+            session.setClientDomain("unknown");        
             return null;
 
         }


### PR DESCRIPTION
**Affected versions:** 0.9.9, 1.0.0, 1.0.1

**Storyline**

This NullPointerException happens while expanding the "%{p}" macro because the remote IP address has no hostname associated with. In this case RFC says that the "%{p}" macro should be replaced with "unknown". 

_This issue makes the "exists" mechanism to not be evaluated correctly!_

**How to reproduce it:**

```
String ipAddress = "10.0.0.1";
String mailFrom = "any@thecraigs.net";
String hostName = "localhost";

DefaultSPF spf = new DefaultSPF();
spf.checkSPF(ipAddress, mailFrom, hostName);
```

**Stacktrace:** 

```
DEBUG|1017-102715225|main|impl.SPF||||||Start SPF-Record lookup for : thecraigs.net
DEBUG|1017-102715324|main|impl.SPF||||||Found 1 SPF-Records
DEBUG|1017-102715325|main|impl.SPF||||||Executing checker: PFC:org.apache.james.jspf.policies.ParseRecordPolicy@35cabb2a
DEBUG|1017-102715325|main|SPF.parser||||||Start parsing SPF-Record: v=spf1 ip4:208.42.240.22 ip4:208.42.240.20 exists:_i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o} ?all
DEBUG|1017-102715331|main|impl.SPF||||||Executing checker: PFC:org.apache.james.jspf.policies.NoSPFRecordFoundPolicy@223d2c72
DEBUG|1017-102715331|main|impl.SPF||||||Executing checker: PFC:org.apache.james.jspf.policies.NeutralIfNotMatchPolicy@8f4ea7c
DEBUG|1017-102715332|main|impl.SPF||||||Executing checker: PFC:org.apache.james.jspf.policies.local.DefaultExplanationPolicy@3febb011
DEBUG|1017-102715333|main|impl.SPF||||||Executing checker: org.apache.james.jspf.impl.SPF$SPFRecordChecker@7f3b84b8
DEBUG|1017-102715334|main|impl.SPF||||||Executing checker: ip4:208.42.240.22
DEBUG|1017-102715334|main|impl.SPF||||||Executing checker: ip4:208.42.240.22
DEBUG|1017-102715335|main|impl.SPF||||||Executing checker: org.apache.james.jspf.terms.Directive$MechanismResultChecker@7f0eb4b4
DEBUG|1017-102715335|main|parser.directive||||||Processed directive NOT matched: org.apache.james.jspf.terms.Directive$MechanismResultChecker@7f0eb4b4
DEBUG|1017-102715335|main|impl.SPF||||||Executing checker: ip4:208.42.240.20
DEBUG|1017-102715335|main|impl.SPF||||||Executing checker: ip4:208.42.240.20
DEBUG|1017-102715335|main|impl.SPF||||||Executing checker: org.apache.james.jspf.terms.Directive$MechanismResultChecker@5c33f1a9
DEBUG|1017-102715335|main|parser.directive||||||Processed directive NOT matched: org.apache.james.jspf.terms.Directive$MechanismResultChecker@5c33f1a9
DEBUG|1017-102715335|main|impl.SPF||||||Executing checker: exists:_i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o}
DEBUG|1017-102715335|main|impl.SPF||||||Executing checker: exists:_i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o}
DEBUG|1017-102715336|main|SPF.macroExpand||||||Start expand domain: _i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o}
DEBUG|1017-102715336|main|SPF.macroExpand||||||Used macro: i replaced with: 10.0.0.1
DEBUG|1017-102715337|main|impl.SPF||||||Start PTR-Record lookup for : 1.0.0.10.in-addr.arpa
DEBUG|1017-102715345|main|impl.SPF||||||Found 0 PTR-Records
DEBUG|1017-102715346|main|impl.SPF||||||Executing checker: org.apache.james.jspf.terms.ExistsMechanism$ExpandedChecker@223191a6
DEBUG|1017-102715346|main|SPF.macroExpand||||||Start expand domain: _i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o}
DEBUG|1017-102715346|main|SPF.macroExpand||||||Used macro: i replaced with: 10.0.0.1
ERROR|1017-102715346|main|impl.SPF||||||null
java.lang.NullPointerException
    at org.xbill.DNS.Name.fromString(Name.java:301)
    at org.xbill.DNS.Name.fromString(Name.java:319)
    at org.apache.james.jspf.core.DNSRequest.<init>(DNSRequest.java:52)
    at org.apache.james.jspf.terms.ExistsMechanism$ExpandedChecker.checkSPF(ExistsMechanism.java:53)
    at org.apache.james.jspf.executor.SynchronousSPFExecutor.execute(SynchronousSPFExecutor.java:54)
    at org.apache.james.jspf.impl.SPF.checkSPF(SPF.java:315)
```

**SPF record of thecraigs.net :**

```
v=spf1 ip4:208.42.240.22 ip4:208.42.240.20 exists:_i-%{i}._p-%{p}._h-%{h}._l-%{l}._o-%{o}._spf.%{o} ?all
```
