### PR TITLE
Fixup asynchronous spf executor

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/executor/AsynchronousSPFExecutor.java
+++ b/resolver/src/main/java/org/apache/james/jspf/executor/AsynchronousSPFExecutor.java
@@ -73,7 +73,10 @@ public class AsynchronousSPFExecutor implements SPFExecutor {
         dnsProbe.getRecordsAsync(cont.getRequest())
             .thenAccept(results -> {
                 try {
-                    cont.getListener().onDNSResponse(new DNSResponse(results), session);
+                    DNSLookupContinuation lookupContinuation = cont.getListener().onDNSResponse(new DNSResponse(results), session);
+                    if (lookupContinuation != null) {
+                        doGetRecordAsync(session, lookupContinuation, finalChecker);
+                    }
                 } catch (PermErrorException | NoneException | TempErrorException | NeutralException e) {
                     handleError(session, finalChecker, e);
                 }

--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -1,0 +1,38 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+
+package org.apache.james.jspf;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.james.jspf.executor.SPFResult;
+import org.apache.james.jspf.impl.DefaultSPF;
+import org.apache.james.jspf.impl.SPF;
+import org.junit.Test;
+
+public class AsynchronousSPFExecutorIntegrationTest {
+
+    @Test
+    public void test() {
+        SPF spf = new DefaultSPF();
+        SPFResult result = spf.checkSPF("192.99.55.226", "nico@bytle.net", "beau.bytle.net");
+        assertEquals(result.getResult(), "pass");
+        assertEquals(result.getHeader(),"Received-SPF: pass (spfCheck: domain of bytle.net designates 192.99.55.226 as permitted sender) client-ip=192.99.55.226; envelope-from=nico@bytle.net; helo=beau.bytle.net;");
+    }
+}


### PR DESCRIPTION
### What bug?

When query case ` --ip 192.99.55.226 --sender nico@bytle.net --helo beau.bytle.net` 
The result of `AsynchronousSPFExecutor` is not correct (and different with `SynchronousSPFExecutor`)

The bug was  reported at https://issues.apache.org/jira/browse/JAMES-3920
```
Just to add that it does not work either with the command line tool

From the Jspf Assembly, version  [1.03](https://mvnrepository.com/artifact/org.apache.james.jspf/apache-jspf/1.0.3) :

java -cp ".\*;.\lib\*" org.apache.james.jspf.impl.SPFQuery --ip 192.99.55.226 --sender nico@bytle.net --helo beau.bytle.net
Result:

none
Received-SPF: none (spfCheck: 192.99.55.226 is neither permitted nor denied by domain of bytle.net) client-ip=192.99.55.226; envelope-from=nico@bytle.net; helo=beau.bytle.net;

From  the SpfQuery command line (libspf)

spfquery -ip=192.99.55.226 -sender=nico@eraldy.com -helo=beau.bytle.net
Received-SPF: pass (spfquery: domain of eraldy.com designates 192.99.55.226 as permitted sender) client-ip=192.99.55.226; envelope-from=nico@eraldy.com; helo=beau.bytle.net;
```

###  Why?
1. Because several SPFChecker were run asynchronous, 
but checkerA depends on the result of checkerB  
=> if checkerA run before checkerB => wrong logic => throw error
2. Another bug: https://github.com/apache/james-jspf/commit/3bf78121e4a07b48df744fafaccb2a351a7005e9

### How to fix it
I do not understand all checkers, 
My PR just shows my idea rather than a solution