### PR TITLE
Fixed asynchronous hanging w/truncated SPF record

### DIFF
--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -39,4 +39,16 @@ public class AsynchronousSPFExecutorIntegrationTest {
         assertEquals("Received-SPF: pass (spfCheck: domain of linagora.com designates 109.197.176.25 as permitted sender) client-ip=109.197.176.25; envelope-from=nico@linagora.com; helo=linagora.com;",
             result.getHeader());
     }
+
+    @Test
+    public void shouldParseWireParseExceptionRecordTruncated() {
+        SPF spf = new DefaultSPF();
+        SPFResult result = spf.checkSPF("170.146.224.15", "HelpDesk@arcofmc.org", "arcofmc.org");
+        System.out.println(result.getResult());
+        System.out.println(result.getExplanation());
+        System.out.println(result.getHeader());
+        assertEquals("permerror", result.getResult());
+        assertEquals("Received-SPF: permerror (spfCheck: Error in processing SPF Record) client-ip=170.146.224.15; envelope-from=HelpDesk@arcofmc.org; helo=arcofmc.org;",
+            result.getHeader());
+    }
 }

--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -29,18 +29,8 @@ import org.apache.james.jspf.impl.DefaultSPF;
 import org.apache.james.jspf.impl.SPF;
 import org.junit.Test;
 
-import org.xbill.DNS.Resolver;
 import org.xbill.DNS.ExtendedResolver;
 import org.apache.james.jspf.impl.DNSServiceXBillImpl;
-import org.apache.james.jspf.wiring.WiringServiceTable;
-import org.apache.james.jspf.core.MacroExpand;
-import org.apache.james.jspf.core.DNSServiceEnabled;
-import org.apache.james.jspf.core.MacroExpandEnabled;
-import org.apache.james.jspf.impl.DefaultTermsFactory;
-import org.apache.james.jspf.parser.RFC4408SPF1Parser;
-import org.apache.james.jspf.executor.AsynchronousSPFExecutor;
-import org.apache.james.jspf.executor.SPFExecutor;
-import org.apache.james.jspf.core.SPFCheckEnabled;
 
 public class AsynchronousSPFExecutorIntegrationTest {
 

--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -20,16 +20,61 @@
 package org.apache.james.jspf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.net.UnknownHostException;
 
 import org.apache.james.jspf.executor.SPFResult;
 import org.apache.james.jspf.impl.DefaultSPF;
 import org.apache.james.jspf.impl.SPF;
 import org.junit.Test;
 
+import org.xbill.DNS.Resolver;
+import org.xbill.DNS.ExtendedResolver;
+import org.apache.james.jspf.impl.DNSServiceXBillImpl;
+import org.apache.james.jspf.wiring.WiringServiceTable;
+import org.apache.james.jspf.core.MacroExpand;
+import org.apache.james.jspf.core.DNSServiceEnabled;
+import org.apache.james.jspf.core.MacroExpandEnabled;
+import org.apache.james.jspf.impl.DefaultTermsFactory;
+import org.apache.james.jspf.parser.RFC4408SPF1Parser;
+import org.apache.james.jspf.executor.AsynchronousSPFExecutor;
+import org.apache.james.jspf.executor.SPFExecutor;
+import org.apache.james.jspf.core.SPFCheckEnabled;
+
 public class AsynchronousSPFExecutorIntegrationTest {
 
+    private SPF createAsyncSPF() {
+        return createAsyncSPF((String[]) null);
+    }
+
+    private SPF createAsyncSPF(String dnsResolvers) {
+        return createAsyncSPF(dnsResolvers.split("\\s*;\\s*"));
+    }
+
+    /**
+     * Mimics the logic in the new SPF() 
+     */
+    private SPF createAsyncSPF(String[] dnsResolvers) {
+        DNSServiceXBillImpl dnsProbe;
+
+        // when we have no specific DNS resolvers to use, we use the default DNS of the JVM 
+        if( dnsResolvers == null ){
+            dnsProbe = new DNSServiceXBillImpl();
+        } else {
+            try {
+                dnsProbe = new DNSServiceXBillImpl(new ExtendedResolver(dnsResolvers));
+            } catch (UnknownHostException e) {
+                fail("Resolver could not be created");
+                dnsProbe = null;
+            }
+        }
+
+        return new SPF(dnsProbe);
+    }
+
     @Test
-    public void test() {
+    public void testWithDefaultSPF() {
         SPF spf = new DefaultSPF();
         SPFResult result = spf.checkSPF("109.197.176.25", "nico@linagora.com", "linagora.com");
         System.out.println(result.getResult());
@@ -41,8 +86,20 @@ public class AsynchronousSPFExecutorIntegrationTest {
     }
 
     @Test
-    public void shouldParseWireParseExceptionRecordTruncated() {
-        SPF spf = new DefaultSPF();
+    public void testSPFWithAsynchronousSPFExecutor() {
+        SPF spf = createAsyncSPF(); 
+        SPFResult result = spf.checkSPF("109.197.176.25", "nico@linagora.com", "linagora.com");
+        System.out.println(result.getResult());
+        System.out.println(result.getExplanation());
+        System.out.println(result.getHeader());
+        assertEquals("pass", result.getResult());
+        assertEquals("Received-SPF: pass (spfCheck: domain of linagora.com designates 109.197.176.25 as permitted sender) client-ip=109.197.176.25; envelope-from=nico@linagora.com; helo=linagora.com;",
+            result.getHeader());
+    }
+
+    @Test
+    public void shouldParseWireParseExceptionWhenRecordTruncated() {
+        SPF spf = createAsyncSPF("1.1.1.1; 1.0.0.1"); // use CloudFlare's DNS server to resolve DNS entries
         SPFResult result = spf.checkSPF("170.146.224.15", "HelpDesk@arcofmc.org", "arcofmc.org");
         System.out.println(result.getResult());
         System.out.println(result.getExplanation());


### PR DESCRIPTION
This fixes and issue in the `AsynchronousSPFExecutor` where threads would hang when reading an SPF record that was truncated because there were too many DNS lookups required.

This includes a unit test, but I could only figure out a way to implement a test w/a real DNS record, so it could break in the future if the DNS record for the domain gets fixed.

NOTE - I do believe there's a possibility there are other hard DNS exceptions that could cause the same behavior, but since I could only trigger the bug with a live DNS record, could not find a good way to test alternative scenarios.