### PR TITLE
Set sync executor as default

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/executor/AsynchronousSPFExecutor.java
+++ b/resolver/src/main/java/org/apache/james/jspf/executor/AsynchronousSPFExecutor.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.xbill.DNS.lookup.NoSuchRRSetException;
 
 /**
- * Synchronous implementation of SPFExecuter. All queries will get executed synchronously
+ * Asynchronous implementation of SPFExecutor. All queries will get executed asynchronously
  */
 public class AsynchronousSPFExecutor implements SPFExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(AsynchronousSPFExecutor.class);

--- a/resolver/src/main/java/org/apache/james/jspf/impl/DefaultSPF.java
+++ b/resolver/src/main/java/org/apache/james/jspf/impl/DefaultSPF.java
@@ -19,11 +19,43 @@
 
 package org.apache.james.jspf.impl;
 
+import org.apache.james.jspf.core.DNSService;
+import org.apache.james.jspf.executor.AsynchronousSPFExecutor;
+import org.apache.james.jspf.executor.SPFExecutor;
+import org.apache.james.jspf.executor.SynchronousSPFExecutor;
+
 public class DefaultSPF extends SPF {
     /**
-     * Uses DNSJava based dns resolver
+     * Creates an instance with the default dns resolver and a SynchronousSPFExecutor
+     *
+     * @see #createAsync()
+     * @see #createSync()
+     * @see SPF#SPF(DNSService, SPFExecutor)
      */
     public DefaultSPF() {
         super(new DNSServiceXBillImpl());
+    }
+
+    /**
+     * Creates an instance of {@link SPF} with a default dns resolver and a {@link SynchronousSPFExecutor}
+     *
+     * @see #createAsync()
+     * @see SPF#SPF(DNSService, SPFExecutor)
+     * @return SPF
+     */
+    public static SPF createSync() {
+        return new SPF(new DNSServiceXBillImpl());
+    }
+
+    /**
+     * Creates an instance of {@link SPF} with a default dns resolver and a {@link AsynchronousSPFExecutor}
+     *
+     * @see #createSync()
+     * @see SPF#SPF(DNSService, SPFExecutor)
+     * @return SPF
+     */
+    public static SPF createAsync() {
+        DNSServiceXBillImpl dnsService = new DNSServiceXBillImpl();
+        return new SPF(dnsService, new AsynchronousSPFExecutor(dnsService));
     }
 }

--- a/resolver/src/main/java/org/apache/james/jspf/impl/SPF.java
+++ b/resolver/src/main/java/org/apache/james/jspf/impl/SPF.java
@@ -22,7 +22,6 @@ package org.apache.james.jspf.impl;
 
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.james.jspf.core.DNSLookupContinuation;
 import org.apache.james.jspf.core.DNSService;
@@ -46,7 +45,6 @@ import org.apache.james.jspf.executor.AsynchronousSPFExecutor;
 import org.apache.james.jspf.executor.FutureSPFResult;
 import org.apache.james.jspf.executor.SPFExecutor;
 import org.apache.james.jspf.executor.SPFResult;
-import org.apache.james.jspf.executor.SynchronousSPFExecutor;
 import org.apache.james.jspf.parser.RFC4408SPF1Parser;
 import org.apache.james.jspf.policies.InitialChecksPolicy;
 import org.apache.james.jspf.policies.NeutralIfNotMatchPolicy;
@@ -64,6 +62,7 @@ import org.apache.james.jspf.policies.local.TrustedForwarderPolicy;
 import org.apache.james.jspf.wiring.WiringServiceTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xbill.DNS.lookup.NoSuchDomainException;
 
 /**
  * This class is used to generate a SPF-Test and provided all intressting data.
@@ -266,6 +265,9 @@ public class SPF implements SPFChecker {
                 if (!SPFErrorConstants.NEUTRAL_CONV.equals(result)) {
                     LOGGER.warn(exception.getMessage(),exception);
                 }
+            } else if(exception instanceof NoSuchDomainException) {
+                LOGGER.error(exception.getMessage(), exception);
+                result = SPFErrorConstants.NONE_CONV;
             } else {
                 // this should never happen at all. But anyway we will set the
                 // result to neutral. Safety first ..

--- a/resolver/src/test/java/org/apache/james/jspf/DefaultSPFResolverTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/DefaultSPFResolverTest.java
@@ -25,8 +25,13 @@ import org.junit.Test;
 
 public class DefaultSPFResolverTest {
     @Test
-    public void shouldHandleNotFound() {
+    public void shouldHandleDomainNotFound() {
         String spfResult = new DefaultSPF().checkSPF("207.54.72.202","do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de","reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de").getResult();
+        Assert.assertEquals("none", spfResult);
+    }
+    @Test
+    public void shouldHandleSPFNotFound() {
+        String spfResult = new DefaultSPF().checkSPF("207.54.72.202","do_not_reply@de","de").getResult();
         Assert.assertEquals("none", spfResult);
     }
 }

--- a/resolver/src/test/java/org/apache/james/jspf/DefaultSPFResolverTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/DefaultSPFResolverTest.java
@@ -27,6 +27,6 @@ public class DefaultSPFResolverTest {
     @Test
     public void shouldHandleNotFound() {
         String spfResult = new DefaultSPF().checkSPF("207.54.72.202","do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de","reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de").getResult();
-        Assert.assertEquals("neutral", spfResult);
+        Assert.assertEquals("none", spfResult);
     }
 }

--- a/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.james.jspf;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.james.jspf.executor.SPFResult;
 import org.apache.james.jspf.impl.DefaultSPF;
 import org.apache.james.jspf.impl.SPF;
@@ -31,7 +29,9 @@ import org.xbill.DNS.SimpleResolver;
 
 import java.net.UnknownHostException;
 
-public class AsynchronousSPFExecutorIntegrationTest {
+import static org.junit.Assert.assertEquals;
+
+public class SynchronousSPFExecutorIntegrationTest {
     @BeforeClass
     public static void setup() {
         System.out.println("Setting default resolver");
@@ -44,7 +44,7 @@ public class AsynchronousSPFExecutorIntegrationTest {
 
     @Test
     public void test() {
-        SPF spf = DefaultSPF.createAsync();
+        SPF spf = DefaultSPF.createSync();
         SPFResult result = spf.checkSPF("109.197.176.25", "nico@linagora.com", "linagora.com");
         System.out.println(result.getResult());
         System.out.println(result.getExplanation());
@@ -56,7 +56,7 @@ public class AsynchronousSPFExecutorIntegrationTest {
 
     @Test
     public void shouldHandleDomainNotFound() {
-        SPF spf = DefaultSPF.createAsync();
+        SPF spf = DefaultSPF.createSync();
         SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de","reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de");
         System.out.println(result.getResult());
         System.out.println(result.getExplanation());
@@ -66,7 +66,7 @@ public class AsynchronousSPFExecutorIntegrationTest {
 
     @Test
     public void shouldHandleSPFNotFound() {
-        SPF spf = DefaultSPF.createAsync();
+        SPF spf = DefaultSPF.createSync();
         SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@de","de");
         System.out.println(result.getResult());
         System.out.println(result.getExplanation());


### PR DESCRIPTION
AsynchronousSPFExecutor is the cause of many problems since it was made default in the commit https://github.com/apache/james-jspf/commit/3ea9bffa7b6344c4d85e801b5b703510f613b155. This PR changes the default back to SynchronousSPFExecutor and add methods to create instances with sync or async executors.