### PR TITLE
Use custom resolver for Async

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/impl/DNSServiceXBillImpl.java
+++ b/resolver/src/main/java/org/apache/james/jspf/impl/DNSServiceXBillImpl.java
@@ -187,7 +187,7 @@ public class DNSServiceXBillImpl implements DNSService {
                 throw new IllegalArgumentException();
         }
         LOGGER.debug("Start {}-Record lookup for : {}", recordTypeDescription, request.getHostname());
-        final LookupSession lookupSession = LookupSession.defaultBuilder().build();
+        final LookupSession lookupSession = LookupSession.defaultBuilder().resolver(this.resolver).build();
 
         try {
             return lookupSession.lookupAsync(Name.fromString(request.getHostname()), dnsJavaType)


### PR DESCRIPTION
The resolver passed to constructor shouldn't be ignored.