### PR TITLE
Add tests for dns unreachable and fix hang

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/executor/AsynchronousSPFExecutor.java
+++ b/resolver/src/main/java/org/apache/james/jspf/executor/AsynchronousSPFExecutor.java
@@ -84,10 +84,10 @@ public class AsynchronousSPFExecutor implements SPFExecutor {
                     }
                 })
                 .exceptionally(e -> {
-                    if (e instanceof CompletionException) {
+                    if (e instanceof CompletionException && e.getCause() != null) {
                         e = e.getCause();
                     }
-                    if (e instanceof IOException && e.getMessage().startsWith("Timed out ")) {
+                    if (e instanceof IOException && e.getMessage() != null && e.getMessage().startsWith("Timed out ")) {
                         e = new TimeoutException(e.getMessage());
                     }
                     if (e instanceof NoSuchRRSetException) {

--- a/resolver/src/main/java/org/apache/james/jspf/impl/SPF.java
+++ b/resolver/src/main/java/org/apache/james/jspf/impl/SPF.java
@@ -20,6 +20,7 @@
 
 package org.apache.james.jspf.impl;
 
+import java.net.SocketException;
 import java.util.Iterator;
 import java.util.LinkedList;
 
@@ -287,6 +288,10 @@ public class SPF implements SPFChecker {
             } else if(exception instanceof NoSuchDomainException) {
                 LOGGER.error(exception.getMessage(), exception);
                 result = SPFErrorConstants.NONE_CONV;
+            } else if (exception instanceof SocketException) {
+                //SocketException or PortUnreachableException can be caused by a temporary issue
+                LOGGER.error(exception.getMessage(), exception);
+                result = SPFErrorConstants.TEMP_ERROR_CONV;
             } else {
                 // this should never happen at all. But anyway we will set the
                 // result to neutral. Safety first ..

--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class AsynchronousSPFExecutorIntegrationTest {
     @BeforeClass
     public static void setup() {
-        System.out.println("Setting default resolver");
+        // set default resolver before the tests to avoid errors caused by previous tests
         try {
             Lookup.setDefaultResolver(new SimpleResolver());
         } catch (UnknownHostException e) {
@@ -57,9 +57,6 @@ public class AsynchronousSPFExecutorIntegrationTest {
     public void test() {
         SPF spf = DefaultSPF.createAsync();
         SPFResult result = spf.checkSPF("109.197.176.25", "nico@linagora.com", "linagora.com");
-        System.out.println(result.getResult());
-        System.out.println(result.getExplanation());
-        System.out.println(result.getHeader());
         assertEquals("pass", result.getResult());
         assertEquals("Received-SPF: pass (spfCheck: domain of linagora.com designates 109.197.176.25 as permitted sender) client-ip=109.197.176.25; envelope-from=nico@linagora.com; helo=linagora.com;",
             result.getHeader());
@@ -68,37 +65,34 @@ public class AsynchronousSPFExecutorIntegrationTest {
     @Test
     public void shouldHandleDomainNotFound() {
         SPF spf = DefaultSPF.createAsync();
-        SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de","reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de");
-        System.out.println(result.getResult());
-        System.out.println(result.getExplanation());
-        System.out.println(result.getHeader());
+        SPFResult result = spf.checkSPF("207.54.72.202",
+                "do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de",
+                "reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de");
         assertEquals("none", result.getResult());
+        assertEquals("Received-SPF: none (spfCheck: 207.54.72.202 is neither permitted nor denied by domain of reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de) client-ip=207.54.72.202; envelope-from=do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de; helo=reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de;",
+                result.getHeader());
     }
 
     @Test
     public void shouldHandleSPFNotFound() {
         SPF spf = DefaultSPF.createAsync();
         SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@com.br","com.br");
-        System.out.println(result.getResult());
-        System.out.println(result.getExplanation());
-        System.out.println(result.getHeader());
         assertEquals("none", result.getResult());
+        assertEquals("Received-SPF: none (spfCheck: 207.54.72.202 is neither permitted nor denied by domain of com.br) client-ip=207.54.72.202; envelope-from=do_not_reply@com.br; helo=com.br;",
+                result.getHeader());
     }
 
     @Test
     public void shouldReturnTempErrorOnPortUnreachable() throws UnknownHostException {
         Resolver simpleResolver = new SimpleResolver("127.0.0.1");
         simpleResolver.setPort(ThreadLocalRandom.current().nextInt(55000, 56000));
-
         DNSServiceXBillImpl dns = new DNSServiceXBillImpl(simpleResolver);
-
         SPF spf = new SPF(dns, new AsynchronousSPFExecutor(dns));
         SPFResult result = spf.checkSPF("207.54.72.202",
                 "do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de",
                 "reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de");
-        System.out.println(result.getResult());
-        System.out.println(result.getExplanation());
-        System.out.println(result.getHeader());
         assertEquals("temperror", result.getResult());
+        assertEquals("Received-SPF: temperror (spfCheck: Error in retrieving data from DNS) client-ip=207.54.72.202; envelope-from=do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de; helo=reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de;",
+                result.getHeader());
     }
 }

--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -26,8 +26,10 @@ import org.apache.james.jspf.executor.SPFResult;
 import org.apache.james.jspf.impl.DNSServiceXBillImpl;
 import org.apache.james.jspf.impl.DefaultSPF;
 import org.apache.james.jspf.impl.SPF;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xbill.DNS.DClass;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Resolver;
 import org.xbill.DNS.SimpleResolver;
@@ -44,6 +46,11 @@ public class AsynchronousSPFExecutorIntegrationTest {
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Before
+    public void clearDnsCache() {
+        Lookup.getDefaultCache(DClass.IN).clearCache();
     }
 
     @Test

--- a/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/AsynchronousSPFExecutorIntegrationTest.java
@@ -67,7 +67,7 @@ public class AsynchronousSPFExecutorIntegrationTest {
     @Test
     public void shouldHandleSPFNotFound() {
         SPF spf = DefaultSPF.createAsync();
-        SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@de","de");
+        SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@com.br","com.br");
         System.out.println(result.getResult());
         System.out.println(result.getExplanation());
         System.out.println(result.getHeader());

--- a/resolver/src/test/java/org/apache/james/jspf/DNSServiceXBillImplTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/DNSServiceXBillImplTest.java
@@ -21,61 +21,56 @@
 package org.apache.james.jspf;
 
 import org.apache.james.jspf.impl.DNSServiceXBillImpl;
+import org.junit.Test;
 import org.xbill.DNS.DClass;
-import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Name;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.SPFRecord;
 import org.xbill.DNS.TXTRecord;
-import org.xbill.DNS.TextParseException;
 import org.xbill.DNS.Type;
 
-import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
-public class DNSServiceXBillImplTest extends TestCase {
-
-    protected void setUp() throws Exception {
-        super.setUp();
+public class DNSServiceXBillImplTest {
+    @Test
+    public void testGetLocalDomainNames() throws UnknownHostException {
+        assertFalse(new DNSServiceXBillImpl().getLocalDomainNames().isEmpty());
     }
 
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
-    /*
-     * Test method for
-     * 'org.apache.james.jspf.DNSServiceXBillImpl.getLocalDomainNames()'
-     */
-    public void testGetLocalDomainNames() throws UnknownHostException,
-            TextParseException {
-        // This write MACHINE-NAME/MACHINE-ADDRESS
-        System.out.println(InetAddress.getLocalHost());
-        // THIS WRITE localhost/127.0.0.1
-        System.out.println(InetAddress.getAllByName(null)[0]);
-        // THIS WRITE a fully qualified MACHINE-NAME.MACHINE-DOMAIN
-        System.out.println(InetAddress.getLocalHost().getCanonicalHostName());
-        // THIS WRITE localhost
-        System.out.println(InetAddress.getAllByName(null)[0]
-                .getCanonicalHostName());
-        Record[] record = new Lookup(Name.root, Type.ANY).run();
-        if (record !=null) System.out.println(record[0]);
-    }
-    
+    @Test
     public void testMultipleStrings() throws Exception {
-        Record[] rr = new Record[] { TXTRecord.fromString(Name.fromString("test.local."), Type.TXT, DClass.IN, 0, "\"string \" \"concatenated\"", Name.fromString("local.")) };
-        assertEquals("string concatenated", DNSServiceXBillImpl.convertRecordsToList(rr).get(0));
+        Record[] rr = new Record[]{
+                TXTRecord.fromString(Name.fromString("test.local."),
+                        Type.TXT, DClass.IN, 0, "\"string \" \"concatenated\"", Name.fromString("local."))};
+        List<String> records = DNSServiceXBillImpl.convertRecordsToList(rr);
+        assertNotNull(records);
+        assertEquals("string concatenated", records.get(0));
 
-        rr = new Record[] { TXTRecord.fromString(Name.fromString("test.local."), Type.TXT, DClass.IN, 0, "string", Name.fromString("local.")) };
-        assertEquals("string", DNSServiceXBillImpl.convertRecordsToList(rr).get(0));
+        rr = new Record[]{
+                TXTRecord.fromString(Name.fromString("test.local."),
+                        Type.TXT, DClass.IN, 0, "string", Name.fromString("local."))};
+        records = DNSServiceXBillImpl.convertRecordsToList(rr);
+        assertNotNull(records);
+        assertEquals("string", records.get(0));
 
-        rr = new Record[] { TXTRecord.fromString(Name.fromString("test.local."), Type.TXT, DClass.IN, 0, "\"quoted string\"", Name.fromString("local.")) };
-        assertEquals("quoted string", DNSServiceXBillImpl.convertRecordsToList(rr).get(0));
+        rr = new Record[]{
+                TXTRecord.fromString(Name.fromString("test.local."),
+                        Type.TXT, DClass.IN, 0, "\"quoted string\"", Name.fromString("local."))};
+        records = DNSServiceXBillImpl.convertRecordsToList(rr);
+        assertNotNull(records);
+        assertEquals("quoted string", records.get(0));
 
-        rr = new Record[] { SPFRecord.fromString(Name.fromString("test.local."), Type.SPF, DClass.IN, 0, "\"quot\" \"ed st\" \"ring\"", Name.fromString("local.")) };
-        assertEquals("quoted string", DNSServiceXBillImpl.convertRecordsToList(rr).get(0));
+        rr = new Record[]{
+                SPFRecord.fromString(Name.fromString("test.local."),
+                        Type.SPF, DClass.IN, 0, "\"quot\" \"ed st\" \"ring\"", Name.fromString("local."))};
+        records = DNSServiceXBillImpl.convertRecordsToList(rr);
+        assertNotNull(records);
+        assertEquals("quoted string", records.get(0));
     }
 
 }

--- a/resolver/src/test/java/org/apache/james/jspf/DefaultSPFResolverTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/DefaultSPFResolverTest.java
@@ -31,7 +31,7 @@ public class DefaultSPFResolverTest {
     }
     @Test
     public void shouldHandleSPFNotFound() {
-        String spfResult = new DefaultSPF().checkSPF("207.54.72.202","do_not_reply@de","de").getResult();
+        String spfResult = new DefaultSPF().checkSPF("207.54.72.202","do_not_reply@com.br","com.br").getResult();
         Assert.assertEquals("none", spfResult);
     }
 }

--- a/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
@@ -25,8 +25,10 @@ import org.apache.james.jspf.executor.SynchronousSPFExecutor;
 import org.apache.james.jspf.impl.DNSServiceXBillImpl;
 import org.apache.james.jspf.impl.DefaultSPF;
 import org.apache.james.jspf.impl.SPF;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xbill.DNS.DClass;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Resolver;
 import org.xbill.DNS.SimpleResolver;
@@ -45,6 +47,11 @@ public class SynchronousSPFExecutorIntegrationTest {
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Before
+    public void clearDnsCache() {
+        Lookup.getDefaultCache(DClass.IN).clearCache();
     }
 
     @Test

--- a/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
@@ -19,15 +19,20 @@
 
 package org.apache.james.jspf;
 
+import org.apache.james.jspf.executor.AsynchronousSPFExecutor;
 import org.apache.james.jspf.executor.SPFResult;
+import org.apache.james.jspf.executor.SynchronousSPFExecutor;
+import org.apache.james.jspf.impl.DNSServiceXBillImpl;
 import org.apache.james.jspf.impl.DefaultSPF;
 import org.apache.james.jspf.impl.SPF;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Resolver;
 import org.xbill.DNS.SimpleResolver;
 
 import java.net.UnknownHostException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
 
@@ -72,5 +77,22 @@ public class SynchronousSPFExecutorIntegrationTest {
         System.out.println(result.getExplanation());
         System.out.println(result.getHeader());
         assertEquals("none", result.getResult());
+    }
+
+    @Test
+    public void shouldReturnTempErrorOnPortUnreachable() throws UnknownHostException {
+        Resolver simpleResolver = new SimpleResolver("127.0.0.1");
+        simpleResolver.setPort(ThreadLocalRandom.current().nextInt(55000, 56000));
+
+        DNSServiceXBillImpl dns = new DNSServiceXBillImpl(simpleResolver);
+
+        SPF spf = new SPF(dns, new SynchronousSPFExecutor(dns));
+        SPFResult result = spf.checkSPF("207.54.72.202",
+                "do_not_reply@reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de",
+                "reyifglerifwukfvbdjhrkbvebvekvfulervkerkeruerbeb.de");
+        System.out.println(result.getResult());
+        System.out.println(result.getExplanation());
+        System.out.println(result.getHeader());
+        assertEquals("temperror", result.getResult());
     }
 }

--- a/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/SynchronousSPFExecutorIntegrationTest.java
@@ -67,7 +67,7 @@ public class SynchronousSPFExecutorIntegrationTest {
     @Test
     public void shouldHandleSPFNotFound() {
         SPF spf = DefaultSPF.createSync();
-        SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@de","de");
+        SPFResult result = spf.checkSPF("207.54.72.202","do_not_reply@com.br","com.br");
         System.out.println(result.getResult());
         System.out.println(result.getExplanation());
         System.out.println(result.getHeader());


### PR DESCRIPTION
This PR adds tests to reproduce DNS unreachable condition which causes a hang when async executor is in use, works flawlessly with sync.