### PR TITLE
Fix SPFSession inAddress

### DIFF
--- a/resolver/src/main/java/org/apache/james/jspf/core/SPFSession.java
+++ b/resolver/src/main/java/org/apache/james/jspf/core/SPFSession.java
@@ -46,7 +46,7 @@ public class SPFSession implements MacroData {
 
     private String currentDomain = ""; // (d)<current-domain>
 
-    private String inAddress = "in-addr"; // (v)
+    private String inAddress = "invalid"; // (v)
 
     private String clientDomain = null; // (p)
 

--- a/resolver/src/test/java/org/apache/james/jspf/core/SPFSessionTest.java
+++ b/resolver/src/test/java/org/apache/james/jspf/core/SPFSessionTest.java
@@ -19,19 +19,47 @@
 
 package org.apache.james.jspf.core;
 
-import org.apache.james.jspf.core.exceptions.NoneException;
-import org.apache.james.jspf.core.exceptions.PermErrorException;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class SPFSessionTest extends TestCase {
-
-    /*
-     * Test method for 'org.apache.james.jspf.core.SPF1Data.getMacroIpAddress()'
-     */
-    public void testGetMacroIpAddress() throws PermErrorException, NoneException {
+public class SPFSessionTest {
+    @Test
+    public void testGetMacroIpAddress() {
         SPFSession d = new SPFSession("mailfrom@fromdomain.com","helodomain.com","2001:DB8::CB01");
         assertEquals("2.0.0.1.0.D.B.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.C.B.0.1",d.getMacroIpAddress());
     }
 
+    @Test
+    public void shouldReturnInvalidIP6() {
+        String addr = "2001:db8::644:f:f:f:x";
+        SPFSession spfSession = new SPFSession("", "", addr);
+        assertEquals("invalid", spfSession.getInAddress());
+    }
+
+    @Test
+    public void shouldReturnInvalidIP4() {
+        String addr = "192.168.0.256";
+        SPFSession spfSession = new SPFSession("", "", addr);
+        assertEquals("invalid", spfSession.getInAddress());
+    }
+
+    @Test
+    public void shouldReturnValidIP6() {
+        String addr = "2001:db8::644:f:f:f:1";
+        SPFSession spfSession = new SPFSession("", "", addr);
+        assertEquals("ip6", spfSession.getInAddress());
+    }
+
+    @Test
+    public void shouldReturnIPv4Mapped() {
+        SPFSession spfSession = new SPFSession("", "", "::ffff:192.168.1.1");
+        assertEquals("ip6", spfSession.getInAddress());
+    }
+
+    @Test
+    public void shouldReturnIPv4() {
+        SPFSession spfSession = new SPFSession("", "", "192.168.1.1");
+        assertEquals("in-addr", spfSession.getInAddress());
+    }
 }


### PR DESCRIPTION
The inAddress field should not end up with a "in-addr" when the exception was handled in the constructor in the event of an invalid address is passed to IPAddr check. This commit sets the default value to "invalid" and adds some ip tests for SPFSession.

The issue [JSPF-100](https://issues.apache.org/jira/projects/JSPF/issues/JSPF-100) is somewhat related to this, but I think there's no issue at all. Considering a pure IPv4 software would never be able to use the IPv4 mapped address, it only makes sense to consider it as IPv6, unless IPv4 mapped would be useful which doesn't appear to be the case. Also, this method doesn't seem to be used.